### PR TITLE
Fix LLM CLI command parsing and provider configuration

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -94,13 +94,13 @@ config :rubber_duck, :llm,
           """
         }
       ]
+    },
+    # Ollama provider for local LLM
+    %{
+      name: :ollama,
+      adapter: RubberDuck.LLM.Providers.Ollama,
+      base_url: "http://localhost:11434",
+      models: ["llama2", "codellama", "mistral"],
+      timeout: 60_000
     }
-    # Ollama provider for local LLM (optional - uncomment if you have Ollama installed)
-    # %{
-    #   name: :ollama,
-    #   adapter: RubberDuck.LLM.Providers.Ollama,
-    #   base_url: "http://localhost:11434",
-    #   models: ["llama2", "codellama", "mistral"],
-    #   timeout: 60_000
-    # }
   ]

--- a/config/llm.exs
+++ b/config/llm.exs
@@ -1,7 +1,7 @@
 import Config
 
 # LLM Service Configuration
-config :rubber_duck, RubberDuck.LLM.Service,
+config :rubber_duck, :llm,
   providers: [
     %{
       name: :openai,
@@ -72,7 +72,7 @@ config :rubber_duck, RubberDuck.LLM.Service,
 
 # Development overrides
 if config_env() == :dev do
-  config :rubber_duck, RubberDuck.LLM.Service,
+  config :rubber_duck, :llm,
     providers: [
       %{
         name: :mock,
@@ -84,13 +84,24 @@ if config_env() == :dev do
         options: [
           simulate_delay: true
         ]
+      },
+      %{
+        name: :ollama,
+        adapter: RubberDuck.LLM.Providers.Ollama,
+        base_url: System.get_env("OLLAMA_BASE_URL", "http://localhost:11434"),
+        models: ["llama2", "llama2:7b", "llama2:13b", "mistral", "codellama", "mixtral"],
+        priority: 2,
+        rate_limit: nil,
+        max_retries: 3,
+        timeout: 60_000,
+        options: []
       }
     ]
 end
 
 # Test overrides
 if config_env() == :test do
-  config :rubber_duck, RubberDuck.LLM.Service,
+  config :rubber_duck, :llm,
     providers: [
       %{
         name: :mock,

--- a/lib/rubber_duck/cli/commands/llm.ex
+++ b/lib/rubber_duck/cli/commands/llm.ex
@@ -8,30 +8,26 @@ defmodule RubberDuck.CLI.Commands.LLM do
   @doc """
   Handles LLM management commands.
   """
-  def run(args, config) do
-    subcommand = get_subcommand(args)
-
+  def run(subcommand, args, config) when is_atom(subcommand) do
+    # Direct call from Runner with subcommand as first arg
     case subcommand do
-      "status" -> show_status(args, config)
-      "connect" -> connect_provider(args, config)
-      "disconnect" -> disconnect_provider(args, config)
-      "enable" -> enable_provider(args, config)
-      "disable" -> disable_provider(args, config)
+      :status -> show_status(args, config)
+      :connect -> connect_provider(args, config)
+      :disconnect -> disconnect_provider(args, config)
+      :enable -> enable_provider(args, config)
+      :disable -> disable_provider(args, config)
       _ -> {:error, "Unknown LLM subcommand: #{subcommand}"}
     end
   end
 
-  defp get_subcommand(args) do
-    # The subcommand is the first non-option argument after "llm"
-    args[:args] |> List.first() || "status"
+  def run(args, config) do
+    # Legacy call pattern - default to status
+    show_status(args, config)
   end
 
   defp get_provider_arg(args) do
-    # The provider is the second non-option argument
-    case args[:args] do
-      [_subcommand, provider | _] -> provider
-      _ -> nil
-    end
+    # The provider is a named argument in the args map
+    args[:provider]
   end
 
   defp show_status(_args, config) do

--- a/lib/rubber_duck/cli/config.ex
+++ b/lib/rubber_duck/cli/config.ex
@@ -28,12 +28,22 @@ defmodule RubberDuck.CLI.Config do
   Creates a configuration from parsed command-line arguments.
   """
   def from_parsed_args(parsed) do
+    # Handle different parsed formats (struct vs map)
+    {options, flags} = case parsed do
+      %Optimus.ParseResult{options: opts, flags: flgs} ->
+        {opts, flgs}
+      %{options: opts, flags: flgs} ->
+        {opts, flgs}
+      _ ->
+        {%{}, %{}}
+    end
+    
     config = %__MODULE__{
-      format: get_in(parsed, [:options, :format]) || :plain,
-      verbose: get_in(parsed, [:flags, :verbose]) || false,
-      quiet: get_in(parsed, [:flags, :quiet]) || false,
-      debug: get_in(parsed, [:flags, :debug]) || false,
-      config_file: get_in(parsed, [:options, :config])
+      format: Map.get(options, :format, :plain),
+      verbose: Map.get(flags, :verbose, false),
+      quiet: Map.get(flags, :quiet, false),
+      debug: Map.get(flags, :debug, false),
+      config_file: Map.get(options, :config)
     }
 
     # Load user preferences from config file if specified

--- a/lib/rubber_duck/cli/runner.ex
+++ b/lib/rubber_duck/cli/runner.ex
@@ -41,7 +41,19 @@ defmodule RubberDuck.CLI.Runner do
   end
 
   defp execute_command(:llm, args, config) do
-    Commands.LLM.run(args, config)
+    # For llm command with nested subcommands, we need to handle it differently
+    # args will have the structure from the nested subcommand
+    case args do
+      %{subcommand: nil} ->
+        # No subcommand specified, default to status
+        Commands.LLM.run(:status, %{}, config)
+      %{subcommand: {subcommand, subcommand_args}} ->
+        # Pass the subcommand and its args
+        Commands.LLM.run(subcommand, subcommand_args, config)
+      _ ->
+        # Fallback - might be direct args
+        Commands.LLM.run(:status, args, config)
+    end
   end
 
   defp execute_command(nil, _args, _config) do

--- a/lib/rubber_duck/llm/providers/ollama.ex
+++ b/lib/rubber_duck/llm/providers/ollama.ex
@@ -108,6 +108,7 @@ defmodule RubberDuck.LLM.Providers.Ollama do
     {:error, :not_supported}
   end
 
+  # This is the old single-argument health_check for backward compatibility
   @impl true
   def health_check(%ProviderConfig{} = config) do
     url = build_url(config, "/api/tags")

--- a/lib/rubber_duck/llm/service.ex
+++ b/lib/rubber_duck/llm/service.ex
@@ -320,7 +320,8 @@ defmodule RubberDuck.LLM.Service do
   # Private Functions
 
   defp load_config(opts) do
-    app_config = Application.get_env(:rubber_duck, __MODULE__, [])
+    # Get config from :rubber_duck, :llm to match ConnectionManager
+    app_config = Application.get_env(:rubber_duck, :llm, [])
 
     config = Keyword.merge(app_config, opts)
 


### PR DESCRIPTION
- Convert llm command to use nested subcommands for proper argument parsing
- Update CLI execute function to handle Optimus tuple format for nested subcommands
- Fix Config module to properly extract options from Optimus.ParseResult struct
- Update Runner to correctly pass subcommand and args to LLM command handler
- Fix LLM provider configuration to use consistent config key across modules
- Enable ollama provider in development configuration
- Update LLM.Service to use same config key as ConnectionManager

This resolves the "provider_not_configured" error and enables proper connection to LLM providers through the CLI.